### PR TITLE
style: 에러메시지 있을때 스타일 적용

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "githubPullRequests.ignoredPullRequestBranches": ["develop"]
+}

--- a/app/(auth)/_components/InputField.tsx
+++ b/app/(auth)/_components/InputField.tsx
@@ -6,7 +6,7 @@ interface InputFieldProps {
   label: string;
   placeholder: string;
   register: UseFormRegisterReturn;
-  type: string;
+  type?: string;
   errorMessage?: string;
   className?: string;
 }
@@ -31,11 +31,13 @@ export default function InputField({
         placeholder={placeholder}
         {...register}
         autoComplete="off"
-        className={`rounded-lg border border-gray200 bg-white px-4 py-3 text-gray500 placeholder-gray350 placeholder:text-[16px] placeholder:font-semibold placeholder:leading-[22px] focus:border-main focus:outline-none ${className}`}
+        className={`rounded-lg border bg-white px-4 py-3 font-semibold placeholder-gray350 placeholder:text-[16px] placeholder:font-semibold placeholder:leading-[22px] focus:outline-none ${errorMessage ? 'border-warning text-warning' : 'border-gray200 text-gray500'} ${className}`}
       />
-
-      <p className="min-h-[20px] pl-[10px] pt-1 text-[12px] font-medium leading-[16px] text-warning">
-        {errorMessage}
+      <p
+        className="min-h-[20px] pl-[10px] pt-1 text-[12px] font-medium leading-[16px] text-warning"
+        style={{ visibility: errorMessage ? 'visible' : 'hidden' }}
+      >
+        {errorMessage || ' '}
       </p>
     </div>
   );

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -39,19 +39,15 @@ export default function LoginPage() {
   const onSubmit = (data: LoginFormData) => {
     loginMutate(data, {
       onSuccess: (responseData) => {
-        // if (!responseData.result || !responseData.result.user) {
-        //   toast.error('로그인 정보가 올바르지 않습니다.');
-        //   return;
-        // }
-
-        const { user } = responseData.result;
-        setInfo({
-          id: user.id,
-          email: user.email,
-          name: user.username
-        });
-
-        router.refresh();
+        if (responseData.result && responseData.result.user) {
+          const { user } = responseData.result;
+          setInfo({
+            id: user.id,
+            email: user.email,
+            name: user.username
+          });
+          router.refresh();
+        }
       }
     });
   };

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { useForm } from 'react-hook-form';
-import toast from 'react-hot-toast';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import axios from 'axios';
@@ -40,10 +39,10 @@ export default function LoginPage() {
   const onSubmit = (data: LoginFormData) => {
     loginMutate(data, {
       onSuccess: (responseData) => {
-        if (!responseData.result || !responseData.result.user) {
-          toast.error('로그인 정보가 올바르지 않습니다.');
-          return;
-        }
+        // if (!responseData.result || !responseData.result.user) {
+        //   toast.error('로그인 정보가 올바르지 않습니다.');
+        //   return;
+        // }
 
         const { user } = responseData.result;
         setInfo({


### PR DESCRIPTION
# ☘ 관련 이슈
> #50

# 📝 작업 내용 요약

> 작업한 내용을 간략히 작성해주세요.

- input 보더 수정
- warning일때 text색상도 warning으로 설정

# 📸 스크린샷(선택)
![스크린샷 2025-02-11 오후 5 01 53](https://github.com/user-attachments/assets/d59c1f01-9e60-4519-a926-6a2f4c6d9d89)


# 🗂 참고 자료(선택)

🔗링크를 추가해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - VS Code의 GitHub Pull Requests 확장 프로그램에서 특정 브랜치(예: "develop")를 무시하도록 설정을 추가했습니다.
- **Style**
  - 입력 필드 컴포넌트의 오류 메시지 표시 방식을 개선하여, 오류 발생 시 시각적 피드백과 레이아웃 일관성을 강화했습니다.
- **Refactor**
  - 로그인 프로세스에서 불필요한 오류 알림 처리를 제거하여, 사용자 경험을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->