### PR TITLE
refactor: 할일 완료 요청 엔드포인트 수정 및 최신순 정렬

### DIFF
--- a/api/todo.ts
+++ b/api/todo.ts
@@ -30,8 +30,11 @@ export const deleteTodoItem = async (id: number) => {
 };
 
 export const updateTodoStatus = async (id: number, done: boolean): Promise<TodoListType> => {
-  const response = await apiWithClientToken.patch<{ result: TodoListType }>(`/todos/${id}`, {
-    done
-  });
+  const response = await apiWithClientToken.patch<{ result: TodoListType }>(
+    `/todos/completion/${id}`,
+    {
+      done
+    }
+  );
   return response.data.result;
 };

--- a/api/todo.ts
+++ b/api/todo.ts
@@ -20,7 +20,7 @@ export const readTodoList = async ({
   else if (filter === 'To do') doneParam = false;
 
   const response = await apiWithClientToken.get<{ result: TodoListType }>('/todos', {
-    params: { lastSeenId: pageParam, pageSize: pageSize, done: doneParam }
+    params: { lastSeenId: pageParam, pageSize, done: doneParam }
   });
   return response.data.result;
 };

--- a/app/dashboard/_components/LatestTodoList.tsx
+++ b/app/dashboard/_components/LatestTodoList.tsx
@@ -17,7 +17,11 @@ export default function LatestTodoList({ queryClient }: { queryClient: QueryClie
 
   const { data } = useQuery<TodoListType>({
     queryKey: ['todos', userId, isSmallScreen],
-    queryFn: () => readTodoList({ pageSize: isSmallScreen ? 3 : 4 })
+    queryFn: () => readTodoList({ pageSize: isSmallScreen ? 3 : 4 }),
+    select: (data) => ({
+      ...data,
+      todos: [...(data.todos ?? [])].toReversed()
+    })
   });
 
   return (

--- a/app/dashboard/_components/LatestTodoList.tsx
+++ b/app/dashboard/_components/LatestTodoList.tsx
@@ -20,7 +20,7 @@ export default function LatestTodoList({ queryClient }: { queryClient: QueryClie
     queryFn: () => readTodoList({ pageSize: isSmallScreen ? 3 : 4 }),
     select: (data) => ({
       ...data,
-      todos: [...(data.todos ?? [])].toReversed()
+      todos: (data.todos ?? []).toReversed()
     })
   });
 

--- a/app/todoList/page.tsx
+++ b/app/todoList/page.tsx
@@ -34,7 +34,13 @@ export default function TodoListPage() {
     enabled: !!userId,
     retry: 0,
     placeholderData: (previousData) => previousData,
-    refetchOnWindowFocus: false
+    refetchOnWindowFocus: false,
+    select: (data) => ({
+      ...data,
+      pages: data.pages.flatMap((page) => ({
+        todos: [...(page.todos ?? [])].toReversed()
+      }))
+    })
   });
 
   // 1. 필터링 (All, To do, Done)

--- a/app/todoList/page.tsx
+++ b/app/todoList/page.tsx
@@ -38,7 +38,7 @@ export default function TodoListPage() {
     select: (data) => ({
       ...data,
       pages: data.pages.flatMap((page) => ({
-        todos: [...(page.todos ?? [])].toReversed()
+        todos: (page.todos ?? []).toReversed()
       }))
     })
   });


### PR DESCRIPTION
# ☘ 관련 이슈
> #73 

** 현재 이슈는 다른 사람이 등록한 할 일들도 내 할 일 목록에 표시되고 있는데,,
내가 등록한 할 일에 대해 완료 및 삭제 요청을 보내면 UI에 즉시 업데이트됩니다.

# 📝 작업 내용 요약

- 할 일 항목 완료 요청 엔드포인트 수정
- 할 일 목록 최신순으로 정렬

# 📸 스크린샷(선택)

![_-미루지마-Chrome-2025-02-14-01-33-00](https://github.com/user-attachments/assets/1fa6fa58-8f34-4d06-88e9-9b7bd1e950d2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 할 일 목록이 역순으로 정렬되어 최신 항목이 상단에 표시됩니다. 이로 인해 최근 작업을 보다 직관적으로 확인할 수 있습니다.
  - 할 일 목록 페이지에서 API 요청 시 데이터 구조가 변경되어 더 효율적으로 처리됩니다.

- **리팩토링**
  - 할 일 데이터 조회와 업데이트 과정에서 API 요청 방식이 간소화되어 작업의 일관성과 효율성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->