### PR TITLE
fix: 차트 y축 최대값 추가

### DIFF
--- a/app/dashboard/_components/weeklyChart/Chart.tsx
+++ b/app/dashboard/_components/weeklyChart/Chart.tsx
@@ -1,4 +1,4 @@
-import { Bar, BarChart, ResponsiveContainer, XAxis } from 'recharts';
+import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from 'recharts';
 
 import useIsSmallScreen from '@/hooks/nav/useIsSmallScreen';
 
@@ -35,6 +35,8 @@ export default function Chart({ data }: { data: ChartDataType[] }) {
         </defs>
 
         <XAxis dataKey="day" scale="point" axisLine={false} tickLine={false} orientation="top" />
+
+        <YAxis domain={[0, 100]} hide />
 
         <Bar
           dataKey="percentage"

--- a/stores/modalStore.ts
+++ b/stores/modalStore.ts
@@ -1,6 +1,5 @@
 import { createStore } from 'zustand/vanilla';
 
-
 export type createModalType = {
   title: string;
   done: boolean;
@@ -41,10 +40,6 @@ export type ModalState = {
   confirmTempNoteModalProps?: ConfirmTempNoteModalProps;
   noteLinkModalProps?: NoteLinkModalProps;
 };
-export type DeleteModalProps = {
-  onConfirm: () => void;
-  onCancel: () => void;
-};
 
 type ConfirmTempNoteModalProps = {
   tempNoteTitle: string | undefined;
@@ -78,7 +73,7 @@ const initModalState = {
 
   isGoalEditModalOpen: false,
   goalDeleteModalProps: undefined,
-  goalEditModalProps: undefined
+  goalEditModalProps: undefined,
   confirmTempNoteModalProps: undefined,
   noteLinkModalProps: undefined
 };


### PR DESCRIPTION
# ☘ 관련 이슈
> #107 

# 📝 작업 내용 요약

> Y축의 범위를 [0, 100]으로 고정하여, 차트가 전체 할 일에서 완료된 할 일의 비율을 기준으로 표시되도록 했습니다.

# 📸 스크린샷(선택)
- 수정 전
![image](https://github.com/user-attachments/assets/1478ce53-02c0-4056-a1dd-6e4e39d2f178)

- 수정 후
![image](https://github.com/user-attachments/assets/e98df1c9-0560-4401-8260-782332f97569)

🔗링크를 추가해주세요.
[https://recharts.org/en-US/api/YAxis](https://recharts.org/en-US/api/YAxis)
