### PR TITLE
fix: 노트 모아보기에서 노트 수정 클릭 시 route 오류 수정

### DIFF
--- a/app/(workspace)/(note)/_components/noteCardList/NoteCardList.tsx
+++ b/app/(workspace)/(note)/_components/noteCardList/NoteCardList.tsx
@@ -24,11 +24,11 @@ export default function NoteCardList({ noteList }: Props) {
   const { mutate } = useDeleteNote(Number(goalId));
 
   const onClickNote = (id: number) => {
-    router.push(`/notes/${id}`, { scroll: false });
+    return () => router.push(`/notes/${id}`, { scroll: false });
   };
 
   const onClickEdit = (todoId: number) => {
-    return () => router.push(`/notes/create?todoId=${todoId}`);
+    return () => router.push(`/notes/create/${todoId}`);
   };
 
   const onClickDelete = (noteId: number) => {
@@ -42,7 +42,7 @@ export default function NoteCardList({ noteList }: Props) {
           <NoteCard
             key={note.createdAt}
             note={note}
-            onClickNote={onClickNote}
+            onClickNote={onClickNote(note.id)}
             onClickEdit={onClickEdit(note.todoDto.id)}
             onClickDelete={onClickDelete(note.id)}
           />

--- a/app/(workspace)/(note)/_components/noteCardList/noteCard/NoteCard.tsx
+++ b/app/(workspace)/(note)/_components/noteCardList/noteCard/NoteCard.tsx
@@ -9,7 +9,7 @@ import type { NoteType } from '@/types/note.type';
 
 interface Props {
   note: NoteType;
-  onClickNote: (id: number) => void;
+  onClickNote: () => void;
   onClickEdit: () => void;
   onClickDelete: () => void;
 }
@@ -17,7 +17,7 @@ interface Props {
 export default function NoteCard({ note, onClickEdit, onClickDelete, onClickNote }: Props) {
   return (
     <article
-      onClick={() => onClickNote(note.id)}
+      onClick={onClickNote}
       className="hover-animate cursor-pointer space-y-[12px] rounded-2xl border border-gray200 bg-white p-6 hover:border-main hover:drop-shadow-note"
     >
       <div className="flex items-center">

--- a/app/(workspace)/(note)/notes/create/[todoId]/page.tsx
+++ b/app/(workspace)/(note)/notes/create/[todoId]/page.tsx
@@ -5,16 +5,16 @@ import { redirect } from 'next/navigation';
 import { readNoteFromServer } from '@/apis/serverActions/note';
 import { readTodoFromServer } from '@/apis/serverActions/todo';
 
-import NoteContent from '../../_components/noteContent/NoteContent';
+import NoteContent from '../../../_components/noteContent/NoteContent';
 
 import type { NoteType } from '@/types/note.type';
 
 interface Props {
-  searchParams: Promise<{ todoId: string }>;
+  params: Promise<{ todoId: string }>;
 }
 
-export default async function CreateNote({ searchParams }: Props) {
-  const { todoId } = await searchParams;
+export default async function CreateNote({ params }: Props) {
+  const { todoId } = await params;
 
   let note: NoteType | null = null;
 

--- a/components/kebab/KebabMenu.tsx
+++ b/components/kebab/KebabMenu.tsx
@@ -34,12 +34,7 @@ export default function KebabMenu({
 
   return (
     <div className="flex-center relative">
-      <button
-        onClick={toggleMenu}
-        onBlur={() => setIsKebabOpen(false)}
-        className="group/more"
-        aria-label="옵션 더보기"
-      >
+      <button onClick={toggleMenu} onBlur={() => setIsKebabOpen(false)} aria-label="옵션 더보기">
         {isKebabOpen ? (
           <KebabFocusIcon width={size} height={size} />
         ) : (
@@ -50,12 +45,24 @@ export default function KebabMenu({
         <div className="absolute right-0 top-full z-10" onMouseDown={(e) => e.preventDefault()}>
           <ul className="relative overflow-hidden rounded-xl bg-white shadow-md">
             <li className="text-nowrap hover:bg-gray-100">
-              <button className="px-4 pb-[6px] pt-2" onClick={onEdit}>
+              <button
+                className="px-4 pb-[6px] pt-2"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit();
+                }}
+              >
                 {editText}
               </button>
             </li>
             <li className="text-nowrap hover:bg-gray-100">
-              <button className="px-4 pb-[6px] pt-2" onClick={onDelete}>
+              <button
+                className="px-4 pb-[6px] pt-2"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+              >
                 {deleteText}
               </button>
             </li>


### PR DESCRIPTION
# ☘ 관련 이슈
> #110

# 📝 작업 내용 요약

> 노트 모아보기 페이지에서 노트 수정하기 클릭 시 `/notes/create?todoId=..` 경로로 이동하는데 intercepting route 시 `create`가 `/notes/[id]`의 `[id]` slug로 취급 받는 오류인 것으로 확인

- 노트 생성 페이지 route depth 추가 `/notes/create/page.tsx` => `/notes/create/[todoId]/page.tsx`
- 노트 생성 페이지에서 `searchParams`가 아닌 `params`로 todoId를 받도록 변경
- 케밥 수정, 삭제 버튼에 핸들러에 `stopPropagation`추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
  - 노트 카드 클릭 시 네비게이션 로직을 개선하여 보다 일관된 탐색 경험 제공.
  - 편집 시 URL이 쿼리 파라미터에서 경로 파라미터로 변경되어 라우팅 구조가 명확해짐.
  - 노트 카드 및 드롭다운 메뉴의 이벤트 처리를 단순화 및 최적화하여 사용자 상호작용이 원활하게 개선됨.
  - 노트 생성 페이지의 매개변수 명칭을 업데이트하여 코드 일관성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->