### PR TITLE
bug: 목표 상세페이지 관련 오류 수정 및 로딩 추가

### DIFF
--- a/app/(workspace)/(note)/noteList/[goalId]/layout.tsx
+++ b/app/(workspace)/(note)/noteList/[goalId]/layout.tsx
@@ -1,6 +1,6 @@
 export const generateMetadata = () => {
   return {
-    title: `목표 상세페이지`
+    title: `노트 모아보기 페이지`
   };
 };
 

--- a/app/(workspace)/goals/[id]/page.tsx
+++ b/app/(workspace)/goals/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
-import React, { useCallback, useEffect, useState } from 'react';
+
+import React, { useCallback, useEffect, useState, useTransition } from 'react';
 
 import { useParams, useRouter } from 'next/navigation';
 
@@ -24,7 +25,6 @@ export default function GoalDetailPage() {
   const goalId = goalIdParam ? parseInt(goalIdParam, 10) : null;
   const goalIdString = goalId ? goalId.toString() : '';
 
-  // Fetch goal detail and todo lists
   const { data: goalData, isLoading, isError } = useGetGoalDetail(goalIdString);
   const { data: todosTodo } = useGetTodoList(goalId, false);
   const { data: todosDone } = useGetTodoList(goalId, true);
@@ -33,31 +33,29 @@ export default function GoalDetailPage() {
   const { mutate: updateGoalTitle } = useUpdateGoalTitle();
   const { mutate: deleteGoalMutate } = useDeleteGoal();
 
-  // Local states
   const [isEditing, setIsEditing] = useState(false);
   const [editedTitle, setEditedTitle] = useState(goalTitle);
   const [activeTab, setActiveTab] = useState<'todo' | 'done'>('todo');
   const [isMounted, setIsMounted] = useState(false);
+  const [isNavigating, setIsNavigating] = useState(false);
 
-  // Modal store actions
+  const [isPending, startTransition] = useTransition();
+
   const setGoalDeleteModalOpen = useModalStore((state) => state.setGoalDeleteModalOpen);
   const setGoalEditModalOpen = useModalStore((state) => state.setGoalEditModalOpen);
   const setIsTodoCreateModalOpen = useModalStore((state) => state.setIsTodoCreateModalOpen);
 
-  // Restore user on mount and set isMounted flag
   useEffect(() => {
     restoreUser();
     setIsMounted(true);
   }, [restoreUser]);
 
-  // Sync edited title with goalTitle when not editing
   useEffect(() => {
     if (!isEditing) {
       setEditedTitle(goalTitle);
     }
   }, [goalTitle, isEditing]);
 
-  // Edit modal handlers
   const handleEditConfirm = useCallback(
     (newTitle: string) => {
       if (!goalId) return;
@@ -93,7 +91,6 @@ export default function GoalDetailPage() {
     });
   }, [goalTitle, handleEditConfirm, handleEditCancel, setGoalEditModalOpen]);
 
-  // Delete modal handlers
   const handleDeleteConfirm = useCallback(() => {
     if (!goalId) return;
     deleteGoalMutate(goalId, {
@@ -115,18 +112,21 @@ export default function GoalDetailPage() {
     });
   }, [handleDeleteConfirm, handleDeleteCancel, setGoalDeleteModalOpen]);
 
-  // Tab and Todo 추가 핸들러
   const handleTabChange = useCallback((tab: 'todo' | 'done') => {
     setActiveTab(tab);
   }, []);
 
-  const handleAddTodo = useCallback(() => {
-    setIsTodoCreateModalOpen(true);
-  }, [setIsTodoCreateModalOpen]);
+  const handleNoteListClick = useCallback(() => {
+    if (!goalId) return;
+    setIsNavigating(true);
+    startTransition(() => {
+      router.push(`/noteList/${goalId}`);
+      setIsNavigating(false);
+    });
+  }, [goalId, router, startTransition]);
 
-  // Loading and error states
   if (!goalId) return <div>유효하지 않은 목표입니다.</div>;
-  if (isLoading)
+  if (isLoading || isNavigating || isPending)
     return (
       <div>
         <SpinIcon />
@@ -159,7 +159,9 @@ export default function GoalDetailPage() {
         />
       </h2>
 
-      <Button onClick={() => router.push(`/noteList/${goalId}`)}>노트 모아보기</Button>
+      <Button onClick={handleNoteListClick}>
+        {isNavigating || isPending ? <SpinIcon /> : '노트 모아보기'}
+      </Button>
 
       <div className="flex flex-col rounded-2xl border border-gray200 bg-white shadow-sm desktop:flex-row desktop:rounded-2xl desktop:p-6">
         <div className="flex rounded-t-lg desktop:hidden">
@@ -190,7 +192,10 @@ export default function GoalDetailPage() {
             <div className="flex-grow"></div>
 
             {activeTab === 'todo' && (
-              <button onClick={handleAddTodo} className="flex items-center text-main">
+              <button
+                onClick={() => setIsTodoCreateModalOpen(true)}
+                className="flex items-center text-main"
+              >
                 <PlusIcon /> 할일 추가
               </button>
             )}

--- a/components/kebab/KebabForGoal.tsx
+++ b/components/kebab/KebabForGoal.tsx
@@ -32,6 +32,11 @@ export default function KebabForGoal({ size, onEdit, onDelete, className }: Keba
     setIsKebabOpen((prev) => !prev);
   };
 
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    setIsKebabOpen(false);
+  };
+
   return (
     <div className={`relative ${className ?? ''}`}>
       <button onClick={toggleMenu} className="rounded-md bg-Cgray" aria-label="목표 수정 및 삭제">
@@ -44,34 +49,37 @@ export default function KebabForGoal({ size, onEdit, onDelete, className }: Keba
       {isKebabOpen &&
         typeof document !== 'undefined' &&
         createPortal(
-          <ul
-            className="absolute z-50 mt-2 box-border flex list-none flex-col whitespace-nowrap rounded-xl border border-gray200 bg-white p-1"
-            style={{ top: menuPosition.top, right: menuPosition.right }}
-            onMouseDown={(e) => e.preventDefault()}
-          >
-            <li className="m-0 flex-nowrap p-0">
-              <button
-                className="flex w-full items-center justify-center px-4 py-2 text-[13px] font-normal leading-[18px] text-gray350 hover:text-gray500"
-                onClick={(e) => {
-                  onEdit();
-                  setIsKebabOpen(false);
-                }}
-              >
-                {KEBAB_MENU_TEXT.edit}
-              </button>
-            </li>
-            <li className="m-0 p-0">
-              <button
-                className="flex w-full items-center justify-center px-4 py-2 text-[13px] font-normal leading-[18px] text-gray350 hover:text-gray500"
-                onClick={(e) => {
-                  onDelete();
-                  setIsKebabOpen(false);
-                }}
-              >
-                {KEBAB_MENU_TEXT.delete}
-              </button>
-            </li>
-          </ul>,
+          <div className="fixed left-0 top-0 z-50 h-full w-full" onClick={handleOverlayClick}>
+            <ul
+              className="z-60 absolute mt-2 box-border flex list-none flex-col whitespace-nowrap rounded-xl border border-gray200 bg-white p-1"
+              style={{ top: menuPosition.top, right: menuPosition.right }}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <li className="m-0 flex-nowrap p-0">
+                <button
+                  className="flex w-full items-center justify-center px-4 py-2 text-[13px] font-normal leading-[18px] text-gray350 hover:text-gray500"
+                  onClick={(e) => {
+                    onEdit();
+                    setIsKebabOpen(false);
+                  }}
+                >
+                  {KEBAB_MENU_TEXT.edit}
+                </button>
+              </li>
+              <li className="m-0 p-0">
+                <button
+                  className="flex w-full items-center justify-center px-4 py-2 text-[13px] font-normal leading-[18px] text-gray350 hover:text-gray500"
+                  onClick={(e) => {
+                    onDelete();
+                    setIsKebabOpen(false);
+                  }}
+                >
+                  {KEBAB_MENU_TEXT.delete}
+                </button>
+              </li>
+            </ul>
+          </div>,
           document.body
         )}
     </div>


### PR DESCRIPTION
# ☘ 관련 이슈
> ex) #129

# 📝 작업 내용 요약

> 작업한 내용을 간략히 작성해주세요.

- 노트로 가는게 너무 오래 걸릴때 로딩 추가
- 수정하기 삭제하기 말고 다른 부분을 누르면 닫힘
- 목표 상세 페이지라고 잘못 작성된 부분 발견후 수정

# 📸 스크린샷(선택)

# 🗂 참고 자료(선택)

🔗링크를 추가해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 페이지 제목이 “노트 모아보기 페이지”로 변경되어, 노트를 한눈에 모아볼 수 있습니다.
  - 목표 상세 페이지에서 노트 리스트로 이동 시 로딩 스피너와 전환 효과가 개선되어 보다 원활한 경험을 제공합니다.
  - 메뉴 외부 클릭 시 드롭다운 메뉴가 자동으로 닫히는 기능이 추가되어 사용성 향상이 이루어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->