### PR TITLE
fix: 노트 리스트페이지 목표 수정 바로 반영

### DIFF
--- a/app/(workspace)/(note)/_components/editGoal/EditGoal.tsx
+++ b/app/(workspace)/(note)/_components/editGoal/EditGoal.tsx
@@ -48,6 +48,8 @@ export default function EditGoal({ goalId }: Props) {
           onSuccess: () => {
             setGoalEditModalOpen(false);
             setEditedTitle(trimmedTitle);
+
+            router.refresh();
           },
           onError: () => setEditedTitle(goalTitle)
         }


### PR DESCRIPTION
# ☘ 관련 이슈
>#150

# 📝 작업 내용 요약

> 노트 리스트 페이지에서 목표 수정 시 목표 제목 바로 반영하기

- `router.refresh()`사용

# 📸 스크린샷(선택)

# 🗂 참고 자료(선택)

🔗링크를 추가해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 목표 제목을 수정한 후 자동으로 페이지가 새로고침되어 변경 사항이 즉시 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->