### PR TITLE
feat: 노트의 링크가 유튜브일 때 임베드 링크로 변환하는 기능

### DIFF
--- a/app/(workspace)/(note)/_components/embedContent/EmbedContent.tsx
+++ b/app/(workspace)/(note)/_components/embedContent/EmbedContent.tsx
@@ -60,7 +60,7 @@ export default function EmbedContent({ linkUrl, isReadOnlyPage }: Props) {
         <iframe
           src={convertYoutubeLinkToEmbedUrl(embedUrl || linkUrl)}
           className="h-3/4 w-full"
-          sandbox="allow-scripts allow-same-origin allow-presentation"
+          sandbox="allow-scripts allow-same-origin"
           referrerPolicy="no-referrer"
         />
       </div>

--- a/app/(workspace)/(note)/_components/embedContent/EmbedContent.tsx
+++ b/app/(workspace)/(note)/_components/embedContent/EmbedContent.tsx
@@ -6,8 +6,7 @@ import Link from 'next/link';
 
 import { useEmbedStore } from '@/provider/store-provider';
 import CloseCircleIcon from '@/public/icon/X-circle.svg';
-
-const mockYoutube = 'https://www.youtube.com/embed/j2LZmDCCpKY';
+import convertYoutubeLinkToEmbedUrl from '@/utils/note/convertYoutubeLinkToEmbedUrl';
 
 interface Props {
   linkUrl: string | undefined;
@@ -59,9 +58,9 @@ export default function EmbedContent({ linkUrl, isReadOnlyPage }: Props) {
           </div>
         </div>
         <iframe
-          src={embedUrl || linkUrl}
+          src={convertYoutubeLinkToEmbedUrl(embedUrl || linkUrl)}
           className="h-3/4 w-full"
-          sandbox="allow-scripts allow-same-origin"
+          sandbox="allow-scripts allow-same-origin allow-presentation"
           referrerPolicy="no-referrer"
         />
       </div>

--- a/utils/note/convertYoutubeLinkToEmbedUrl.ts
+++ b/utils/note/convertYoutubeLinkToEmbedUrl.ts
@@ -9,7 +9,8 @@ const convertYoutubeLinkToEmbedUrl = (link: string | undefined) => {
     const url = new URL(link);
     let videoId = '';
 
-    if (YOUTUBE_DOMAINS.includes(url.hostname) && url.searchParams.has('v')) {
+    const isYoutubeDomain = YOUTUBE_DOMAINS.includes(url.hostname);
+    if (isYoutubeDomain && url.searchParams.has('v')) {
       videoId = url.searchParams.get('v') as string;
       return prefix + videoId;
     } else if (url.hostname === SHORT_YOUTUBE) {

--- a/utils/note/convertYoutubeLinkToEmbedUrl.ts
+++ b/utils/note/convertYoutubeLinkToEmbedUrl.ts
@@ -1,0 +1,26 @@
+const YOUTUBE = 'www.youtube.com';
+const SHORT_YOUTUBE = 'youtu.be';
+const prefix = 'https://' + YOUTUBE + '/embed/';
+
+const convertYoutubeLinkToEmbedUrl = (link: string | undefined) => {
+  if (!link) return undefined;
+
+  try {
+    const url = new URL(link);
+    let videoId = '';
+
+    if (url.hostname === YOUTUBE && url.searchParams.has('v')) {
+      videoId = url.searchParams.get('v') as string;
+      return prefix + videoId;
+    } else if (url.hostname === SHORT_YOUTUBE) {
+      videoId = url.pathname.slice(1);
+      return prefix + videoId;
+    }
+
+    return link;
+  } catch (error) {
+    return '';
+  }
+};
+
+export default convertYoutubeLinkToEmbedUrl;

--- a/utils/note/convertYoutubeLinkToEmbedUrl.ts
+++ b/utils/note/convertYoutubeLinkToEmbedUrl.ts
@@ -1,6 +1,6 @@
-const YOUTUBE = 'www.youtube.com';
+const YOUTUBE_DOMAINS = ['www.youtube.com', 'youtube.com', 'm.youtube.com'];
 const SHORT_YOUTUBE = 'youtu.be';
-const prefix = 'https://' + YOUTUBE + '/embed/';
+const prefix = 'https://www.youtube.com/embed/';
 
 const convertYoutubeLinkToEmbedUrl = (link: string | undefined) => {
   if (!link) return '';
@@ -9,7 +9,7 @@ const convertYoutubeLinkToEmbedUrl = (link: string | undefined) => {
     const url = new URL(link);
     let videoId = '';
 
-    if (url.hostname === YOUTUBE && url.searchParams.has('v')) {
+    if (YOUTUBE_DOMAINS.includes(url.hostname) && url.searchParams.has('v')) {
       videoId = url.searchParams.get('v') as string;
       return prefix + videoId;
     } else if (url.hostname === SHORT_YOUTUBE) {

--- a/utils/note/convertYoutubeLinkToEmbedUrl.ts
+++ b/utils/note/convertYoutubeLinkToEmbedUrl.ts
@@ -3,7 +3,7 @@ const SHORT_YOUTUBE = 'youtu.be';
 const prefix = 'https://' + YOUTUBE + '/embed/';
 
 const convertYoutubeLinkToEmbedUrl = (link: string | undefined) => {
-  if (!link) return undefined;
+  if (!link) return '';
 
   try {
     const url = new URL(link);


### PR DESCRIPTION
# ☘ 관련 이슈
> #140 

# 📝 작업 내용 요약

> 사용자가 입력한 노트 첨부 링크가 유튜브 링크일 때 자동으로 embed로 변환

- `utils/note/convertYoutubeLinkToEmbedUrl` 함수 추가

# 📸 스크린샷(선택)

# 🗂 참고 자료(선택)

🔗링크를 추가해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 유튜브 영상 링크가 자동으로 임베드 형식으로 변환되어, 영상 콘텐츠가 일관되고 원활하게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->