### PR TITLE
fix: 대시보드 페이지 오류 수정

### DIFF
--- a/apis/clientActions/index.ts
+++ b/apis/clientActions/index.ts
@@ -35,7 +35,7 @@ const errorInterceptor = async (error: AxiosError) => {
 
 // ✅ 응답 인터셉터: 정상 응답 로깅
 const responseInterceptor = async (response: AxiosResponse) => {
-  console.log('현재 response', response, response.data?.code, response.status);
+  // console.log('현재 response', response, response.data?.code, response.status);
   return response;
 };
 

--- a/app/(workspace)/goals/_components/NoteDetailModal.tsx
+++ b/app/(workspace)/goals/_components/NoteDetailModal.tsx
@@ -6,18 +6,20 @@ import { useEffect, useState } from 'react';
 import { readNoteFromClient } from '@/apis/clientActions/note';
 import EmbedContent from '@/app/(workspace)/(note)/_components/embedContent/EmbedContent';
 import ReadOnlyNoteContent from '@/app/(workspace)/(note)/_components/readOnlyNoteContent/ReadOnlyNoteContent';
+import { useModalStore } from '@/provider/store-provider';
 
 import NoteModalInGoal from '../_components/NoteModalInGoal';
 
 import type { NoteType } from '@/types/note.type';
 
-interface Props {
+export interface NoteDetailPageModalProps {
   params: Promise<{ id: string }>;
   onClose: () => void;
 }
 
-export default function NoteDetailModal({ params, onClose }: Props) {
+export default function NoteDetailModal({ params, onClose }: NoteDetailPageModalProps) {
   const [note, setNote] = useState<NoteType | null>(null);
+  const setNoteDetailPageOpen = useModalStore((state) => state.setNoteDetailPageOpen);
 
   useEffect(() => {
     (async () => {
@@ -32,6 +34,15 @@ export default function NoteDetailModal({ params, onClose }: Props) {
       }
     })();
   }, [params, onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = '';
+      setNoteDetailPageOpen(false);
+    };
+  }, []);
 
   if (!note) return null;
 

--- a/app/ModalArea.tsx
+++ b/app/ModalArea.tsx
@@ -32,12 +32,12 @@ export default function ModalArea() {
 
   return (
     <>
-      {isNoteDetailPageModalOpen && noteDetailPageModalProps && (
+      {isNoteDetailPageModalOpen && noteDetailPageModalProps ? (
         <NoteDetailModal
           params={noteDetailPageModalProps.params}
           onClose={noteDetailPageModalProps.onClose}
         />
-      )}
+      ) : null}
       {isTodoCreateModalOpen && <TodoCreateModal />}
       {isTodoCreateCheckModalOpen && <TodoCreateCheckModal />}
       {isGoalDeleteModalOpen && goalDeleteModalProps && (

--- a/app/ModalArea.tsx
+++ b/app/ModalArea.tsx
@@ -10,9 +10,12 @@ import { useModalStore } from '@/provider/store-provider';
 import NoteConfirmModal from './(workspace)/(note)/_components/modals/noteConfirmModal/NoteConfirmModal';
 import UploadLinkModal from './(workspace)/(note)/_components/modals/uploadLinkModal/UploadLinkModal';
 import GoalDeleteConfirmModal from './(workspace)/goals/_components/GoalDeleteConfirmModal';
+import NoteDetailModal from './(workspace)/goals/_components/NoteDetailModal';
 
 export default function ModalArea() {
   const {
+    isNoteDetailPageModalOpen,
+    noteDetailPageModalProps,
     isNoteConfirmModalOpen,
     noteConfirmModalProps,
     isNoteLinkModalOpen,
@@ -29,6 +32,12 @@ export default function ModalArea() {
 
   return (
     <>
+      {isNoteDetailPageModalOpen && noteDetailPageModalProps && (
+        <NoteDetailModal
+          params={noteDetailPageModalProps.params}
+          onClose={noteDetailPageModalProps.onClose}
+        />
+      )}
       {isTodoCreateModalOpen && <TodoCreateModal />}
       {isTodoCreateCheckModalOpen && <TodoCreateCheckModal />}
       {isGoalDeleteModalOpen && goalDeleteModalProps && (

--- a/app/dashboard/_components/LatestTodoList.tsx
+++ b/app/dashboard/_components/LatestTodoList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { motion } from 'motion/react';
 import Link from 'next/link';
 

--- a/app/dashboard/_components/UpcomingGoals.tsx
+++ b/app/dashboard/_components/UpcomingGoals.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
 import useGetGoalList from '@/hooks/useGetGoalList';
 import { getUpcomingDates } from '@/utils/dateUtils';

--- a/app/dashboard/_components/calendar/index.tsx
+++ b/app/dashboard/_components/calendar/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { format } from 'date-fns';
 
 import { WEEK_DAYS } from '@/constant/date';

--- a/app/dashboard/_components/goals/GoalItem.tsx
+++ b/app/dashboard/_components/goals/GoalItem.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
 import TaskList from '@/components/TaskList/TaskList';
@@ -23,6 +23,7 @@ interface GoalItemProps {
 }
 
 export default function GoalItem({ goalId, title, todos }: GoalItemProps) {
+  const router = useRouter();
   const userId = useInfoStore((state) => state.userId);
   const setIsTodoCreateModalOpen = useModalStore((state) => state.setIsTodoCreateModalOpen);
   const setCreatedTodoState = useTodoCreateModalStore((state) => state.setCreatedTodoState);
@@ -68,9 +69,13 @@ export default function GoalItem({ goalId, title, todos }: GoalItemProps) {
     setIsMoreToggle((prev) => !prev);
   };
 
+  const handleGoalClick = () => {
+    router.push(`/goals/${goalId}`);
+  };
+
   return (
     <div className="relative">
-      <Link href={`/goals/${goalId}`}>
+      <article onClick={handleGoalClick}>
         <div className="rounded-container mb-4 w-full cursor-pointer p-6" ref={ref}>
           <div className="flex justify-between">
             <h3 className="truncate pr-16 text-lg font-semibold">{title}</h3>
@@ -104,7 +109,7 @@ export default function GoalItem({ goalId, title, todos }: GoalItemProps) {
             </div>
           </div>
         </div>
-      </Link>
+      </article>
 
       <div className="absolute right-6 top-6 z-10 text-xs">
         <button onClick={handleAddTodo} className="flex-center text-main">

--- a/app/dashboard/_components/goals/GoalList.tsx
+++ b/app/dashboard/_components/goals/GoalList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { motion } from 'motion/react';
 
 import LoadingSpinner from '@/components/loading/LoadingSpinner';

--- a/app/dashboard/_components/weeklyChart/index.tsx
+++ b/app/dashboard/_components/weeklyChart/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 
 import { apiWithClientToken } from '@/apis/clientActions';

--- a/components/TodoItem/TodoItem.tsx
+++ b/components/TodoItem/TodoItem.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
-import NoteDetailModal from '@/app/(workspace)/goals/_components/NoteDetailModal';
 import KebabForGoal from '@/components/kebab/KebabForGoal';
 import { PRIORITY_COLORS } from '@/constant/priorityColor';
 import { useCheckTodo } from '@/hooks/goalsDetail/useCheckTodoStatus';
@@ -34,8 +33,8 @@ export default function TodoItem({ todo, goalId }: TodoItemProps) {
   const mutation = useDeleteTodoItem(goalId);
   const { mutate: toggleTodo } = useCheckTodo();
   const setIsTodoCreateModalOpen = useModalStore((state) => state.setIsTodoCreateModalOpen);
+  const setNoteDetailPageOpen = useModalStore((state) => state.setNoteDetailPageOpen);
   const [isPenLoading, setIsPenLoading] = useState(false);
-  const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
 
   // 1) 케밥 메뉴 열림/닫힘 상태
   const [isKebabSelected, setIsKebabSelected] = useState(false);
@@ -44,7 +43,11 @@ export default function TodoItem({ todo, goalId }: TodoItemProps) {
 
   const handleNoteIconClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setIsNoteModalOpen(true);
+
+    setNoteDetailPageOpen(true, {
+      params: Promise.resolve({ id: String(todo.noteId) }),
+      onClose: () => setNoteDetailPageOpen(false)
+    });
   };
 
   const handlePenIconClick = (e: React.MouseEvent) => {
@@ -76,17 +79,6 @@ export default function TodoItem({ todo, goalId }: TodoItemProps) {
     e.stopPropagation();
     setIsKebabSelected((prev) => !prev);
   };
-
-  useEffect(() => {
-    if (isNoteModalOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isNoteModalOpen]);
 
   useEffect(() => {
     const handleClickOutside = () => {
@@ -190,13 +182,6 @@ export default function TodoItem({ todo, goalId }: TodoItemProps) {
           </div>
         </div>
       </div>
-
-      {isNoteModalOpen && (
-        <NoteDetailModal
-          params={Promise.resolve({ id: String(todo.noteId) })}
-          onClose={() => setIsNoteModalOpen(false)}
-        />
-      )}
     </>
   );
 }

--- a/stores/modalStore.ts
+++ b/stores/modalStore.ts
@@ -1,5 +1,6 @@
 import { createStore } from 'zustand/vanilla';
 
+import type { NoteDetailPageModalProps } from '@/app/(workspace)/goals/_components/NoteDetailModal';
 import type { NoteConfirmModalProps, NoteLinkModalProps } from '@/types/note.type';
 
 export type createModalType = {
@@ -31,6 +32,7 @@ export type DeleteModalProps = {
 };
 
 export type ModalState = {
+  isNoteDetailPageModalOpen: boolean;
   isNoteConfirmModalOpen: boolean;
   isTodoCreateModalOpen: boolean;
   isTodoCreateCheckModalOpen: boolean;
@@ -41,11 +43,13 @@ export type ModalState = {
   goalEditModalProps?: EditModalProps;
   noteConfirmModalProps?: NoteConfirmModalProps;
   noteLinkModalProps?: NoteLinkModalProps;
+  noteDetailPageModalProps?: NoteDetailPageModalProps;
   isGoalCreateModalOpen: boolean;
   isLoading: boolean;
 };
 
 export type ModalActions = {
+  setNoteDetailPageOpen: (now: boolean, props?: NoteDetailPageModalProps) => void;
   setIsTodoCreateModalOpen: (now: boolean) => void;
   setIsTodoCreateCheckModalOpen: (now: boolean) => void;
   setNoteLinkModalOpen: (now: boolean, props?: NoteLinkModalProps) => void;
@@ -59,6 +63,7 @@ export type ModalActions = {
 export type ModalStore = ModalState & ModalActions;
 
 const initModalState = {
+  isNoteDetailPageModalOpen: false,
   isNoteConfirmModalOpen: false,
   isTodoCreateModalOpen: false,
   isTodoCreateCheckModalOpen: false,
@@ -99,6 +104,13 @@ export const createModalStore = (initState: ModalState = defaultInitState) => {
 
     setIsGoalCreateModalOpen: (now) => set((state) => ({ ...state, isGoalCreateModalOpen: now })),
 
-    setIsLoading: (now) => set((state) => ({ ...state, isLoading: now }))
+    setIsLoading: (now) => set((state) => ({ ...state, isLoading: now })),
+
+    setNoteDetailPageOpen: (now, props) =>
+      set((state) => ({
+        ...state,
+        isNoteDetailPageModalOpen: now,
+        noteDetailPageModalProps: props
+      }))
   }));
 };


### PR DESCRIPTION
# ☘ 관련 이슈
> #166

# 📝 작업 내용 요약

> 대시보드 페이지에서 렌더링되는 노트 상세 페이지 오류 수정

- 대시보드 페이지에서 할일 노트아이콘 클릭 시 발생하는 오류 수정
- 대시보드 페이지 목표별 할 일 목록 섹션 오류 수정
- 콘솔 주석처리
- 임시로 처리함

# 📸 스크린샷(선택)

# 🗂 참고 자료(선택)

🔗링크를 추가해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 노트 상세보기 경험이 개선되어, 모달 대신 전용 페이지로 노트를 확인할 수 있습니다.
  - 모달 창이 활성화될 때 배경 스크롤이 차단되어 사용자 인터페이스가 한층 깔끔해졌습니다.
  - 새로운 노트 상세보기 모달이 추가되어, 세부 정보를 보다 쉽게 확인할 수 있습니다.

- **리팩토링**
  - 목표 항목 클릭 시 전환 방식이 개선되어, 클릭 가능한 영역이 확장되고 내비게이션이 보다 직관적으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->