### PR TITLE
feat: 노트 관련 버튼에 쓰로틀링 적용

### DIFF
--- a/app/(workspace)/(note)/_components/noteContent/NoteContent.tsx
+++ b/app/(workspace)/(note)/_components/noteContent/NoteContent.tsx
@@ -34,6 +34,7 @@ import ContentLayout from '../layout/ContentLayout';
 import type { NoteInputData } from '@/schema/noteSchema';
 import type { CreateNoteType, NoteType, UpdateNoteType } from '@/types/note.type';
 import type { TodoType } from '@/types/todo.type';
+import _ from 'lodash';
 
 interface Props {
   todo: TodoType;
@@ -66,7 +67,7 @@ export default function NoteContent({ todo, note }: Props) {
     }
   });
 
-  const onSubmit: SubmitHandler<NoteInputData> = async (data) => {
+  const onSubmit: SubmitHandler<NoteInputData> = _.throttle(async (data) => {
     const { title, content } = data;
 
     try {
@@ -99,9 +100,9 @@ export default function NoteContent({ todo, note }: Props) {
     } catch (error) {
       toast.error(NOTE_CREATE_ERROR);
     }
-  };
+  }, 1000);
 
-  const onSaveTempNote = () => {
+  const onSaveTempNote = _.throttle(() => {
     onSaveTempToStorage(getValues('title').trim(), getValues('content'), linkUrl);
     toast.success(TEMP_SAVE_SUCCESS, {
       duration: 2000,
@@ -109,9 +110,9 @@ export default function NoteContent({ todo, note }: Props) {
       style: { color: '#F86969', borderRadius: '20px', border: '1px solid #F86969' },
       icon: <SuccessIcon />
     });
-  };
+  }, 1000);
 
-  const onLoadTempNote = () => {
+  const onLoadTempNote = _.throttle(() => {
     if (!tempedNote) return;
 
     setLink(tempedNote.linkUrl);
@@ -122,7 +123,7 @@ export default function NoteContent({ todo, note }: Props) {
     setDefaultNoteContent(tempedNote.content);
     resetHasTempNote();
     toast.success(TEMP_GET_SUCCESS);
-  };
+  }, 1000);
 
   return (
     <ContentLayout>

--- a/hooks/note/useDeleteNote.ts
+++ b/hooks/note/useDeleteNote.ts
@@ -13,7 +13,7 @@ const useDeleteNote = (goalId: number) => {
   const setIsLoading = useModalStore((state) => state.setIsLoading);
 
   return useMutation({
-    mutationFn: (noteId: number) => deleteNote(noteId),
+    mutationFn: deleteNote,
     onMutate: async (noteId) => {
       setIsLoading(true);
 

--- a/hooks/note/useNoteActions.ts
+++ b/hooks/note/useNoteActions.ts
@@ -1,14 +1,16 @@
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 
 import { useModalStore } from '@/provider/store-provider';
 
 import useDeleteNote from './useDeleteNote';
 import toast from 'react-hot-toast';
 import { NOTE_DELETE_ERROR, NOTE_DELETE_SUCCESS } from '@/constant/toastText';
+import _ from 'lodash';
 
 const useNoteActions = (goalId: number | undefined) => {
   const effectGoalId = goalId ?? 0;
   const router = useRouter();
+  const pathname = usePathname();
 
   const { mutate: deleteNoteMutate } = useDeleteNote(effectGoalId);
   const setIsNoteConfirmModalOpen = useModalStore((state) => state.setIsNoteConfirmModalOpen);
@@ -27,16 +29,16 @@ const useNoteActions = (goalId: number | undefined) => {
         type: 'delete',
         contentTitle: title,
         onCancel: () => setIsNoteConfirmModalOpen(false),
-        onConfirm: () => {
+        onConfirm: _.throttle(() => {
           deleteNoteMutate(noteId, {
             onSuccess: () => {
-              router.back();
+              if (pathname.includes('notes')) router.back();
               toast.success(NOTE_DELETE_SUCCESS);
             },
             onError: () => toast.error(NOTE_DELETE_ERROR),
             onSettled: () => setIsNoteConfirmModalOpen(false)
           });
-        }
+        }, 1000)
       });
     };
   };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -36,7 +36,8 @@ export default {
         pressed: '#E45555',
         lightLabel1: '#EBCBFB',
         lightLabel4: '#A8D2F5',
-        lightGray400: '#B3B3B3'
+        lightGray400: '#B3B3B3',
+        mainhover: '#E46161'
       },
       screens: {
         md: '744px',


### PR DESCRIPTION
# ☘ 관련 이슈

> #215

# 📝 작업 내용 요약

> api 통신을 하는 노트 관련 버튼에 쓰로틀링 적용

- 노트 작성/수정/삭제 함수에 쓰로틀링 적용
- 임시 저장 노트 저장/불러오기 함수에 쓰로틀링 적용
- `/noteList`, `/noteList/[goalId]` 페이지에서 노트 삭제 시 전 페이지로 돌아가는 오류 수정

# 📸 스크린샷(선택)

# 🗂 참고 자료(선택)

🔗링크를 추가해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
	- 입력, 임시 저장 및 삭제와 같은 비동기 작업에 1초 간격의 제한을 적용하여 연속 실행 시 안정성을 개선했습니다.
	- 삭제 시 조건에 따른 네비게이션 처리가 추가되어 사용자 경험을 향상했습니다.
- **스타일**
	- 새로운 호버 색상이 도입되어 인터페이스의 시각적 일관성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->