### PR TITLE
style: 랜딩, 노트 관련 페이지 버튼 호버 스타일 추가

### DIFF
--- a/app/(workspace)/(note)/_components/embedContent/EmbedContent.tsx
+++ b/app/(workspace)/(note)/_components/embedContent/EmbedContent.tsx
@@ -41,7 +41,11 @@ export default function EmbedContent({ linkUrl, isReadOnlyPage }: Props) {
             aria-label="임베드 콘텐츠 닫기"
             name="임베드 콘텐츠 닫기 버튼"
           >
-            <CloseCircleIcon width="24" height="24" className="color-animate fill-main" />
+            <CloseCircleIcon
+              width="24"
+              height="24"
+              className="color-animate fill-main hover:fill-mainhover"
+            />
           </button>
           <div className="flex w-full justify-center">
             <Link

--- a/app/(workspace)/(note)/_components/modals/noteConfirmModal/NoteConfirmModal.tsx
+++ b/app/(workspace)/(note)/_components/modals/noteConfirmModal/NoteConfirmModal.tsx
@@ -46,7 +46,7 @@ export default function NoteConfirmModal({ type, contentTitle, onCancel, onConfi
             type="button"
             onClick={onConfirm}
             aria-label="임시 저장 노트 불러오기"
-            className="h-[40px] w-full rounded-lg bg-main text-button2 text-white md:h-[43px] md:text-button1"
+            className="color-animate h-[40px] w-full rounded-lg bg-main text-button2 text-white hover:bg-mainhover md:h-[43px] md:text-button1"
           >
             확인
           </button>

--- a/app/(workspace)/(note)/_components/modals/noteConfirmModal/NoteConfirmModal.tsx
+++ b/app/(workspace)/(note)/_components/modals/noteConfirmModal/NoteConfirmModal.tsx
@@ -38,7 +38,7 @@ export default function NoteConfirmModal({ type, contentTitle, onCancel, onConfi
             type="button"
             onClick={onCancel}
             aria-label="임시 저장 노트 불러오기 취소"
-            className="h-[40px] w-full rounded-lg border border-main text-button2 text-main md:h-[43px] md:text-button1"
+            className="color-animate h-[40px] w-full rounded-lg border border-main text-button2 text-main hover:bg-solid md:h-[43px] md:text-button1"
           >
             취소
           </button>

--- a/app/(workspace)/(note)/_components/modals/uploadLinkModal/UploadLinkModal.tsx
+++ b/app/(workspace)/(note)/_components/modals/uploadLinkModal/UploadLinkModal.tsx
@@ -68,7 +68,7 @@ export default function UploadLinkModal({ defaultValue, onSubmit, linkInputRef }
         <button
           type="button"
           onClick={onSubmit}
-          className="h-[50px] w-full rounded-lg bg-main px-4 py-3 font-semibold text-white"
+          className="color-animate h-[50px] w-full rounded-lg bg-main px-4 py-3 font-semibold text-white hover:bg-mainhover"
         >
           확인
         </button>

--- a/app/(workspace)/(note)/_components/noteContent/buttonArea/ButtonArea.tsx
+++ b/app/(workspace)/(note)/_components/noteContent/buttonArea/ButtonArea.tsx
@@ -18,7 +18,7 @@ export default function ButtonArea({ isEdit, isValid, onSaveTempNote }: Props) {
           onClick={onSaveTempNote}
           name="임시저장 버튼"
           aria-label="노트 임시저장"
-          className="h-[40px] w-[80px] rounded-lg border border-gray200 bg-white text-[14px] font-semibold text-gray350 md:h-[50px] md:w-[88px]"
+          className="color-animate h-[40px] w-[80px] rounded-lg border border-gray200 bg-white text-[14px] font-semibold text-gray350 hover:bg-whitehover md:h-[50px] md:w-[88px]"
         >
           임시 저장
         </button>
@@ -28,7 +28,7 @@ export default function ButtonArea({ isEdit, isValid, onSaveTempNote }: Props) {
           aria-label="노트 작성완료"
           aria-disabled={!isValid}
           disabled={!isValid}
-          className="h-[40px] w-[80px] rounded-lg bg-solid text-[14px] font-semibold text-main disabled:bg-Cgray disabled:text-gray350 md:h-[50px] md:w-[88px]"
+          className="color-animate h-[40px] w-[80px] rounded-lg bg-solid text-[14px] font-semibold text-main hover:bg-solidhover disabled:bg-Cgray disabled:text-gray350 md:h-[50px] md:w-[88px]"
         >
           {isEdit ? '수정 완료' : '작성 완료'}
         </button>

--- a/app/(workspace)/(note)/_components/noteContent/editor/Editor.tsx
+++ b/app/(workspace)/(note)/_components/noteContent/editor/Editor.tsx
@@ -19,11 +19,11 @@ import {
 import _ from 'lodash';
 
 import useEditor from '@/hooks/note/useEditor';
-import LoadingSpinner from '@/public/icon/spin.svg';
 
 import LinkToolbarButton from './linkToolbarButton/LinkToolbarButton';
 
 import type { NoteInputData } from '@/schema/noteSchema';
+import LoadingSpinner from '@/components/loading/LoadingSpinner';
 
 interface Props {
   defaultContent: string | undefined;
@@ -38,7 +38,7 @@ export default function Editor(props: Props) {
 
   const { editor } = useEditor(defaultContent);
 
-  if (!editor) return <LoadingSpinner width="48" height="48" />;
+  if (!editor) return <LoadingSpinner size={48} />;
 
   const onChange = _.debounce(() => {
     if (setValue) {

--- a/app/(workspace)/(note)/_components/noteContent/tempNote/TempNote.tsx
+++ b/app/(workspace)/(note)/_components/noteContent/tempNote/TempNote.tsx
@@ -37,7 +37,7 @@ export default function TempNote({ tempedNote, onRemove, onLoad }: Props) {
           aria-label="임시 저장 노트 알림 삭제"
           className="flex-center h-4 w-4"
         >
-          <CloseCircleIcon className="fill-main" />
+          <CloseCircleIcon className="color-animate fill-main hover:fill-mainhover" />
         </button>
         <p className="flex flex-wrap text-button2 text-main md:text-button1">
           <span>임시 저장된 노트가 있어요.</span>
@@ -48,7 +48,7 @@ export default function TempNote({ tempedNote, onRemove, onLoad }: Props) {
         type="button"
         onClick={handleConfirmModal}
         aria-label="임시 저장 노트 불러오기"
-        className="h-[32px] w-[73px] rounded-[7px] bg-main text-button2 text-white"
+        className="color-animate h-[32px] w-[73px] rounded-[7px] bg-main text-button2 text-white hover:bg-mainhover"
       >
         불러오기
       </button>

--- a/app/_components/PWAButton/PWAButton.tsx
+++ b/app/_components/PWAButton/PWAButton.tsx
@@ -46,14 +46,14 @@ export default function PWAButton({ className }: Props) {
         <button
           type="button"
           onClick={handleClick}
-          className="h-[40px] w-full animate-bounce rounded-lg bg-main text-button2 text-white md:h-[50px] md:text-button2"
+          className="color-animate h-[40px] w-full animate-bounce rounded-lg bg-main text-button2 text-white hover:bg-mainhover md:h-[50px] md:text-button2"
         >
           앱 다운로드
         </button>
       ) : (
         <Link
           href={valid ? '/dashboard' : '/login'}
-          className="flex-center inline-block h-[40px] w-full rounded-lg bg-main text-button2 text-white md:h-[50px] md:text-button2"
+          className="flex-center color-animate inline-block h-[40px] w-full rounded-lg bg-main text-button2 text-white hover:bg-mainhover md:h-[50px] md:text-button2"
         >
           이대로 사용할래요
         </Link>

--- a/components/NavigationBar/Menus/GoalList.tsx
+++ b/components/NavigationBar/Menus/GoalList.tsx
@@ -37,7 +37,7 @@ export default function GoalList() {
     <>
       <div className="mt-6 box-border flex h-12 items-center gap-2 rounded-[8px] bg-Cgray px-[21px] py-[17px] text-gray500">
         <div className="flex gap-2">
-          <FlagIcon />
+          <FlagIcon width={24} height={24} />
           목표
         </div>
       </div>

--- a/components/NavigationBar/Menus/index.tsx
+++ b/components/NavigationBar/Menus/index.tsx
@@ -42,10 +42,10 @@ export default function Menus() {
 
       <div className="flex flex-col gap-[17px] px-[21px] py-[17px] text-gray400">
         <Link href="/todoList" className="flex items-center gap-[6px]">
-          <TodoListIcon /> <p>할 일 모아보기</p>
+          <TodoListIcon width={18} height={18} /> <p>할 일 모아보기</p>
         </Link>
         <Link href="/noteList" className="flex items-center gap-[6px]">
-          <NoteListIcon /> <p>노트 모아보기</p>
+          <NoteListIcon width={18} height={18} /> <p>노트 모아보기</p>
         </Link>
       </div>
 

--- a/hooks/note/useEditor.ts
+++ b/hooks/note/useEditor.ts
@@ -24,14 +24,12 @@ const useEditor = (defaultContent: string | undefined) => {
       },
       initialContent
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialContent]);
 
   React.useEffect(() => {
     convertDataForEditor(defaultContent).then((content) => {
       setInitialContent(content);
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultContent]);
 
   return { editor };

--- a/modals/iOSPWAGuideModal/IOSPWAGuideModal.tsx
+++ b/modals/iOSPWAGuideModal/IOSPWAGuideModal.tsx
@@ -43,7 +43,7 @@ export default function IOSPWAGuideModal() {
             onClick={() => setIOSPWAGuideModalOpen(false)}
             name="modal-close-button"
             aria-label="확인하고 모달 닫기"
-            className="h-[40px] w-full rounded-lg bg-main text-button2 text-white"
+            className="color-animate h-[40px] w-full rounded-lg bg-main text-button2 text-white hover:bg-mainhover"
           >
             확인
           </button>

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const pwaConfig = {
   dest: 'public',
   register: true,
   skipWaiting: true,
-  // disable: process.env.NODE_ENV === 'development',
+  disable: process.env.NODE_ENV === 'development',
   mode: 'production'
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,7 +37,9 @@ export default {
         lightLabel1: '#EBCBFB',
         lightLabel4: '#A8D2F5',
         lightGray400: '#B3B3B3',
-        mainhover: '#E46161'
+        mainhover: '#E46161',
+        solidhover: '#FDE1E1',
+        whitehover: '#EBEBEB'
       },
       screens: {
         md: '744px',


### PR DESCRIPTION
# ☘ 관련 이슈

>#217

# 📝 작업 내용 요약

> 랜딩, 노트 관련 페이지 버튼들에 호버 스타일 추가

- tailwind.config에 호버 색상 추가
- 이전 svgr 설정 변경으로 인한 네비게이션바 아이콘 크기 오류 수정

# 📸 스크린샷(선택)

# 🗂 참고 자료(선택)

🔗링크를 추가해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 다양한 버튼, 아이콘, 모달 등 주요 UI 요소에 호버 애니메이션과 반응 효과가 추가되어 사용자 인터랙션 경험이 개선되었습니다.
  - 아이콘 및 로딩 스피너의 크기 조정과 새로운 색상 옵션 도입으로 디자인 일관성이 강화되었습니다.
  - 전반적으로 인터페이스의 시각적 피드백과 사용자 경험이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->